### PR TITLE
Fix log redirection for Simulator launch config.

### DIFF
--- a/src/debugConfigProvider.ts
+++ b/src/debugConfigProvider.ts
@@ -62,7 +62,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
         dbgConfig.request = target.type === "Device" ? "launch" : dbgConfig.request;
 
         dbgConfig.initCommands = (dbgConfig.initCommands instanceof Array) ? dbgConfig.initCommands : [];
-        dbgConfig.initCommands.unshift(`command script import ${context.asAbsolutePath("lldb/logs.py")}`);
+        dbgConfig.initCommands.unshift(`command script import '${context.asAbsolutePath("lldb/logs.py")}'`);
         dbgConfig.initCommands.unshift(`platform select ${lldbPlatform[target.type]}`);
 
         return dbgConfig;
@@ -107,9 +107,8 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
                     waitForDebugger: true,
                 });
 
-                let simulatorDataPath = (target as Simulator).dataPath;
-                dbgConfig.initCommands.push(`follow ${path.join(simulatorDataPath, stdout)}`);
-                dbgConfig.initCommands.push(`follow ${path.join(simulatorDataPath, stderr)}`);
+                dbgConfig.initCommands.push(`follow ${stdout}`);
+                dbgConfig.initCommands.push(`follow ${stderr}`);
             }
             else
             {

--- a/src/simulators.ts
+++ b/src/simulators.ts
@@ -1,6 +1,8 @@
 import { Simulator } from './commonTypes';
 import { _execFile } from './utils';
 import * as logger from './logger';
+import * as fs from 'fs';
+import { spawn } from 'child_process';
 
 export async function listSimulators(): Promise<Simulator[]>
 {
@@ -138,33 +140,35 @@ export async function launch(udid: string, bundleId: string, args: string[], env
         simctlEnv[`SIMCTL_CHILD_${key}`] = env[key];
     });
 
-    let {stdout} = await _execFile(
+    spawn(
         'xcrun',
         [
             'simctl', 
             'launch', 
             ...(waitForDebugger ? ['--wait-for-debugger'] : []),
             '--terminate-running-process',
-            ...(stdio?.stdout ? [`--stdout=${stdio.stdout}`] : []),
-            ...(stdio?.stderr ? [`--stderr=${stdio.stderr}`] : []),
+            '--console-pty',
             udid,
             bundleId,
             ...args
         ],
         {
-            env: simctlEnv
+            env: simctlEnv,
+            stdio: ['ignore', fs.openSync(stdio.stdout, 'a'), fs.openSync(stdio.stderr, 'a')]
         }
     );
 
-    let match = stdout.match(new RegExp(`^${bundleId}: (-?\\d+)`));
-
-    if (match && match[1])
-    {
-        let pid = Number.parseInt(match[1]);
-        if (pid > 0)
-        {
+    // simctl doesn't print the pid until the process terminates (output is buffered), so instead
+    // get the pid once the app is launched.
+    let start = new Date().getTime();
+    while (new Date().getTime() - start < 10_000) {
+        try {
+            let pid = await getPidFor(udid, bundleId);
             logger.log(`Launched in ${new Date().getTime() - time} ms`);
             return pid;
+        } catch (error) {
+            logger.log(`Waiting for app to launch`);
+            await new Promise(resolve => setTimeout(resolve, 500));
         }
     }
 

--- a/src/simulators.ts
+++ b/src/simulators.ts
@@ -140,7 +140,7 @@ export async function launch(udid: string, bundleId: string, args: string[], env
         simctlEnv[`SIMCTL_CHILD_${key}`] = env[key];
     });
 
-    spawn(
+    let process = spawn(
         'xcrun',
         [
             'simctl', 
@@ -153,10 +153,11 @@ export async function launch(udid: string, bundleId: string, args: string[], env
             ...args
         ],
         {
-            env: simctlEnv,
-            stdio: ['ignore', fs.openSync(stdio.stdout, 'a'), fs.openSync(stdio.stderr, 'a')]
+            env: simctlEnv
         }
     );
+    process.stdout.pipe(fs.createWriteStream(stdio.stdout));
+    process.stderr.pipe(fs.createWriteStream(stdio.stderr));
 
     // simctl doesn't print the pid until the process terminates (output is buffered), so instead
     // get the pid once the app is launched.


### PR DESCRIPTION
Fixes #3.

It seems that `simctl launch --stdout=* ...` doesn't work anymore, it creates the file but doesn't pipe the output. To fix this, this change launches the app using spawn and pipes sdout/stderr to the files.

Unfortunately simctl buffers printing the pid (it is not printed until the process terminates), so we need to poll for the pid. An alternative would be to spawn using pty (using `node-pty`), or use something like `stdbuf`/`unbuffer` to run `simctl`, but that seems more complex than necessary.