### PR TITLE
Open the Simulator app before launching app.

### DIFF
--- a/src/debugConfigProvider.ts
+++ b/src/debugConfigProvider.ts
@@ -123,6 +123,9 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
 
             dbgConfig.pid = pid;
 
+            dbgConfig.postRunCommands = (dbgConfig.postRunCommands instanceof Array) ? dbgConfig.postRunCommands : [];
+            dbgConfig.postRunCommands.push(`platform shell open -a Simulator --args -CurrentDeviceUDID ${target.udid}`);
+
             delete dbgConfig.env;
             delete dbgConfig.args;
         }

--- a/src/simulators.ts
+++ b/src/simulators.ts
@@ -129,6 +129,8 @@ export async function launch(udid: string, bundleId: string, args: string[], env
     logger.log(`Launching app (id: ${bundleId}) on simulator (udid: ${udid})`);
     let time = new Date().getTime();
 
+    await _execFile('open', ['-a', 'Simulator', '--args', '-CurrentDeviceUDID', udid]);
+
     args = args ?? [];
     env = env ?? {};
 

--- a/src/simulators.ts
+++ b/src/simulators.ts
@@ -129,8 +129,6 @@ export async function launch(udid: string, bundleId: string, args: string[], env
     logger.log(`Launching app (id: ${bundleId}) on simulator (udid: ${udid})`);
     let time = new Date().getTime();
 
-    await _execFile('open', ['-a', 'Simulator', '--args', '-CurrentDeviceUDID', udid]);
-
     args = args ?? [];
     env = env ?? {};
 


### PR DESCRIPTION
This is something I have on my scripts for non-debug runs. Sometimes I start debugging without the Simulator app being open, and it is nice for it to launch automatically (specially because attaching works without it being open, so it can be a bit confusing at first). Feel free to close if you don't think it is useful.