### PR TITLE
Use `simctl bootstatus udid -b` to boot Simulator.

### DIFF
--- a/src/simulators.ts
+++ b/src/simulators.ts
@@ -96,21 +96,7 @@ export async function boot(udid: string): Promise<void>
 {
     logger.log(`Booting simulator (udid: ${udid}) if required`);
     let time = new Date().getTime();
-
-    try
-    {
-        await _execFile('xcrun', ['simctl', 'boot', udid]);
-    }
-    catch (e: any)
-    {
-        let {stderr} = e;
-
-        if (!stderr.match("Unable to boot device in current state: Booted"))
-        {
-            throw e;
-        }
-    }
-
+    await _execFile('xcrun', ['simctl', 'bootstatus', udid, '-b']);
     logger.log(`Booted in ${new Date().getTime() - time} ms`);
 }
 


### PR DESCRIPTION
Noticed this while working on the other pull request, so figured I'd send it. I use `bootstatus` in other scripts and like its behavior better than `boot`, but feel free to close if not interested.

`bootstatus` checks if the Simulator is booted, booting it if it is not. This is the same behavior as before, but built into the `simctl` command. Also, it waits until the device is booted, making the VSCode progress message more correct (before it would say it is installing the app during the boot process).