### PR TITLE
#20 Fix error [ERROR] RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]:…

### DIFF
--- a/src/lib/devices.ts
+++ b/src/lib/devices.ts
@@ -158,7 +158,7 @@ export async function install(target: Device, path: string, cancellationToken: {
     let p = _execFile(
         IOS_DEPLOY,
         ['--id', target.udid, '--faster-path-search', '--timeout', '3', '--bundle', path, '--app_deltas', '/tmp/', '--json'],
-        { env: getIosDeployEnvForSource(target.source) }
+        { maxBuffer: 100 * 1024 * 1024, env: getIosDeployEnvForSource(target.source) }
     );
 
     cancellationToken.cancel = () => p.child.kill();


### PR DESCRIPTION
… stdout maxBuffer length exceeded when install app
Add maxBufferSize=10Mb for stdout/stdin