### PR TITLE
Fix debugging on iOS 17+ devices

### DIFF
--- a/src/lib/targets.ts
+++ b/src/lib/targets.ts
@@ -55,3 +55,8 @@ export async function isValid(target: Target): Promise<boolean>
 
     return isValid;
 }
+
+export function getIosMajorVersion(target: Target): number
+{
+    return parseInt(target.version.split(".")[0]);
+}

--- a/src/targetCommand.ts
+++ b/src/targetCommand.ts
@@ -82,7 +82,7 @@ export async function simulatorInstallAndLaunch(a: {target: Simulator, path: str
 			.then(() => simulator.boot(target))
 			.then(() => progress.report({message: "Installing app"}))
 			.then(() => simulator.install(target, path))
-			.then(() => progress.report({message: "Lauching app"}))
+			.then(() => progress.report({message: "Launching app"}))
 			.then(() => simulator.launch(target, bundleId, args, env, {stdout, stderr}, waitForDebugger))
 			.then((pid) => pid.toString())
 			.catch((e) => {
@@ -157,6 +157,25 @@ export async function deviceInstall(args: {target: Device, path: string})
 					logger.error(e);
 					vscode.window.showErrorMessage("Failed to install app on device");
 				});;
+		});
+}
+
+export async function deviceLaunch(a: {target: Device, bundleId: string, args: string[], env: {[key: string]: string}, stdio: {stdout: string, stderr: string}, waitForDebugger: boolean})
+{
+	let {target, bundleId, args, env, stdio: {stdout, stderr}, waitForDebugger} = await resolveArgs(a);
+
+	return vscode.window.withProgress({
+			"location": vscode.ProgressLocation.Notification,
+			"title": "Launching app",
+			"cancellable": false
+		}, (progress, token) => {
+			return Promise.resolve()
+				.then(() => device.launch(target, bundleId, args, env, {stdout, stderr}, waitForDebugger))
+				.then((pid) => pid.toString())
+				.catch((e) => {
+					logger.error(e);
+					vscode.window.showErrorMessage("Failed to launch app on device");
+				});;;
 		});
 }
 

--- a/src/test/suite/devices.test.ts
+++ b/src/test/suite/devices.test.ts
@@ -5,6 +5,7 @@ import { suiteSetup, suiteTeardown } from 'mocha';
 import * as devices from '../../lib/devices';
 import { _execFile } from '../../lib/utils';
 import { Device } from '../../lib/commonTypes';
+import { getIosMajorVersion } from '../../lib/targets';
 
 const TEST_BUNDLE_IDENTIFIER = "com.ios-debug.Sample-App2";
 
@@ -87,10 +88,13 @@ const testDeviceUDID = process.env["IOS_DEBUG_TEST_DEVICE"] || "";
 		}).timeout(5_000);;
 
 		test('Launch Sample App', async function() {
-			let appPath = path.resolve(__dirname, "../../../examples/Sample App/build/Debug-iphoneos/Sample App.app");
 			launchPid = await devices.launch(
 				testDeviceTarget,
-				appPath
+				TEST_BUNDLE_IDENTIFIER,
+				[],
+				{},
+				{stdout: "/dev/null", stderr: "/dev/null"},
+				false
 			);
 
 			assert(launchPid > 0);
@@ -102,6 +106,10 @@ const testDeviceUDID = process.env["IOS_DEBUG_TEST_DEVICE"] || "";
 		}).timeout(5_000);
 
 		test('Start debugserver', async function() {
+			if (getIosMajorVersion(testDeviceTarget) >= 17) {
+				this.skip();
+			}
+
 			const {port, exec} = await devices.debugserver(testDeviceTarget, {}, (e) => {
 				// Do nothing for now
 			});


### PR DESCRIPTION
ios-deploy is no longer able to create debugserver on recent iOS devices. This broke the debugging for recent iOS devices.

Xcode now ships with devicectl and Apple LLDB supports a new `device` command. Combined, these can be used to support debugging on iOS 17+ devices.

#25 created an excellent POC for this, which helped a lot. This PR builds on top of that and supports more surrounding scenarios like logging as well.